### PR TITLE
Container annotation - command, should be an array of strings 

### DIFF
--- a/quarkus-test-containers/src/main/java/io/quarkus/test/services/Container.java
+++ b/quarkus-test-containers/src/main/java/io/quarkus/test/services/Container.java
@@ -17,7 +17,7 @@ public @interface Container {
 
     String expectedLog();
 
-    String command() default "";
+    String[] command() default {};
 
     Class<? extends ManagedResourceBuilder> builder() default ContainerManagedResourceBuilder.class;
 }

--- a/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/ContainerManagedResourceBuilder.java
+++ b/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/ContainerManagedResourceBuilder.java
@@ -16,7 +16,7 @@ public class ContainerManagedResourceBuilder implements ManagedResourceBuilder {
     private ServiceContext context;
     private String image;
     private String expectedLog;
-    private String command;
+    private String[] command;
     private Integer port;
 
     protected String getImage() {
@@ -27,7 +27,7 @@ public class ContainerManagedResourceBuilder implements ManagedResourceBuilder {
         return expectedLog;
     }
 
-    protected String getCommand() {
+    protected String[] getCommand() {
         return command;
     }
 

--- a/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/GenericDockerContainerManagedResource.java
+++ b/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/GenericDockerContainerManagedResource.java
@@ -26,7 +26,7 @@ public class GenericDockerContainerManagedResource extends DockerContainerManage
             container.waitingFor(new LogMessageWaitStrategy().withRegEx(".*" + model.getExpectedLog() + ".*\\s"));
         }
 
-        if (StringUtils.isNotBlank(model.getCommand())) {
+        if (model.getCommand().length > 0) {
             container.withCommand(model.getCommand());
         }
 


### PR DESCRIPTION
@containner annotation - command should be an array in order to support command arguments.

Example of usage:
```
 @container(image = "strimzi/kafka:0.18.0-kafka-2.5.0", expectedLog = "binding to port 0.0.0.0/0.0.0.0", port = ZK_PORT, command = {"bin/zookeeper-server-start.sh", "config/zookeeper.properties"})
    static final DefaultService zookeper = new DefaultService().withProperty("LOG_DIR", "/tmp/logs");
```